### PR TITLE
Adds Ruff Formatting Check

### DIFF
--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -1,0 +1,18 @@
+name: CI
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff
+      # Update output format to enable automatic inline annotations.
+      - name: Run Ruff
+        run: ruff check --output-format=github .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.9"
 keywords = ["ab initio", "chemistry", "quantum computing"]
 license = { text = "Apache-2.0" }
 dependencies = [
-    # "mhr", # Make this versioned 
+    # "mhr", # Make this versioned
     "qiskit >= 1.4, < 2", # We'll move to 2 eventually
     "qiskit-nature", # Let this be determined by the version of qiskit
     "numpy >= 1.21",
@@ -33,6 +33,6 @@ packages = ["las_qc"]
 [tool.setuptools_scm]
 # version_scheme = "release-branch-semver"
 
-# [tool.ruff.lint]
-# ignore = ["E741"]
-# extend-select = ["I"]
+[tool.ruff.lint]
+ignore = ["E741"]
+extend-select = ["I"]


### PR DESCRIPTION
For shared repositories it's always good to have uniform code formatting and using an automated tool makes this very easy. In the past I've had a good experience with [Ruff](https://docs.astral.sh/ruff/). This PR adds a GitHub action which runs every time you push.

This checks many different rules including:

- Indentation
- Quotes usage
- Import sorting

To check your code locally:

- Install Ruff with pip: `pip install ruff`
- Run `ruff check .`
- Fix by hand or run `ruff check . --fix`
- Fix anything which ruff did not automatically fix